### PR TITLE
Fixes #37 - Expireless tokens

### DIFF
--- a/api/src/config/config.js
+++ b/api/src/config/config.js
@@ -27,19 +27,20 @@ export const general = {
 
 export const tokens = {
   /**
+   * calculateExpirationDate - A simple function to calculate the absolute time that the token is
+   *                          going to expire in.
+   */
+  calculateExpirationDate(expiresIn) {
+    return new Date(Date.now() + (expiresIn * 1000));
+  },
+  /**
    * Configuration of access tokens.
    *
    * expiresIn               - The time in minutes before the access token expires. Default is 60
    *                           minutes
-   * calculateExpirationDate - A simple function to calculate the absolute time that the token is
-   *                           going to expire in.
    */
   accesstoken: {
-    // expires in 100 years
-    expiresIn: 3153600000,
-    calculateExpirationDate() {
-      return new Date(Date.now() + (this.expiresIn * 1000));
-    },
+    expiresIn: 60 * 60,
   },
 
   /**
@@ -58,7 +59,6 @@ export const tokens = {
   refreshToken: {
     expiresIn: 52560000,
   },
-
 };
 
 /**

--- a/api/src/config/config.js
+++ b/api/src/config/config.js
@@ -35,7 +35,8 @@ export const tokens = {
    *                           going to expire in.
    */
   accesstoken: {
-    expiresIn: 60 * 60,
+    // expires in 100 years
+    expiresIn: 3153600000,
     calculateExpirationDate() {
       return new Date(Date.now() + (this.expiresIn * 1000));
     },

--- a/api/src/controllers/OAuth2.js
+++ b/api/src/controllers/OAuth2.js
@@ -131,13 +131,14 @@ server.exchange(oauth2orize.exchange.clientCredentials((client, scope, done) => 
  * request for verification.  If this value is validated, the application issues an access
  * token on behalf of the client who authorized the code
  */
-server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
-  db.refreshToken.findByToken(refreshToken)
-    .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
-    .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
-    .then(token => done(null, token, null, expiresIn))
-    .catch(() => done(null, false));
-}));
+// commented since we are not using refresh tokens
+// server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
+//   db.refreshToken.findByToken(refreshToken)
+//     .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
+//     .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
+//     .then(token => done(null, token, null, expiresIn))
+//     .catch(() => done(null, false));
+// }));
 
 // Register serialialization and deserialization functions.
 //

--- a/api/src/controllers/OAuth2.js
+++ b/api/src/controllers/OAuth2.js
@@ -49,7 +49,7 @@ server.grant(oauth2orize.grant.code((client, redirectURI, user, ares, done) => {
  */
 server.grant(oauth2orize.grant.token((client, user, ares, done) => {
   const token = crypto.createToken({ sub: user.id, exp: config.accesstoken.expiresIn });
-  const expiration = config.accesstoken.calculateExpirationDate();
+  const expiration = config.calculateExpirationDate(config.accesstoken.expiresIn);
 
 
   db.accessTokens.save(token, expiration, user.id, client.id, client.scope)
@@ -117,7 +117,7 @@ server.exchange(oauth2orize.exchange.password((client, username, password, scope
  */
 server.exchange(oauth2orize.exchange.clientCredentials((client, scope, done) => {
   const token = crypto.createToken({ sub: client.id, exp: config.accesstoken.expiresIn });
-  const expiration = config.accesstoken.calculateExpirationDate();
+  const expiration = config.calculateExpirationDate(config.accesstoken.accesstoken);
   // Pass in a null for user id since there is no user when using this grant type
   db.accessTokens.save(token, expiration, null, client.id, scope)
     .then(() => done(null, token, null, expiresIn))
@@ -131,14 +131,13 @@ server.exchange(oauth2orize.exchange.clientCredentials((client, scope, done) => 
  * request for verification.  If this value is validated, the application issues an access
  * token on behalf of the client who authorized the code
  */
-// commented since we are not using refresh tokens
-// server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
-//   db.refreshToken.findByToken(refreshToken)
-//     .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
-//     .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
-//     .then(token => done(null, token, null, expiresIn))
-//     .catch(() => done(null, false));
-// }));
+server.exchange(oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
+  db.refreshToken.findByToken(refreshToken)
+    .then(foundRefreshToken => validate.refreshToken(foundRefreshToken, refreshToken, client))
+    .then(foundRefreshToken => validate.generateToken(foundRefreshToken))
+    .then(token => done(null, token, null, expiresIn))
+    .catch(() => done(null, false));
+}));
 
 // Register serialialization and deserialization functions.
 //

--- a/api/src/controllers/Token.js
+++ b/api/src/controllers/Token.js
@@ -2,7 +2,6 @@
 import { db } from '../utils/db';
 import validate from '../utils/validate';
 
-import models from '../models';
 
 /**
    * This endpoint is for verifying a token.  This has the same signature to
@@ -64,7 +63,8 @@ const info = (req, res) => {
    * {
    *   "error": "invalid_token"
    * }
-   * This will first try to delete the token as an access token.  If one is not found it will try and
+   * This will first try to delete the token as an access token.
+   * If one is not found it will try and
    * delete the token as a refresh token.  If both fail then an error is returned.
    * @param   {Object}  req - The request
    * @param   {Object}  res - The response
@@ -74,7 +74,7 @@ const revoke = (req, res) => validate.tokenForHttp(req.query.token)
   .then(() => db.accessTokens.delete(req.query.token))
   .then((token) => {
     if (token == null) {
-      return db.refreshToken.delete(req.query.token);
+      db.refreshToken.delete(req.query.token).then(refreshToken => refreshToken);
     }
     return token;
   })

--- a/api/src/controllers/Token.js
+++ b/api/src/controllers/Token.js
@@ -74,11 +74,13 @@ const revoke = (req, res) => validate.tokenForHttp(req.query.token)
   .then(() => db.accessTokens.delete(req.query.token))
   .then((token) => {
     if (token == null) {
-      return db.refreshTokens.delete(req.query.token);
+      return db.refreshToken.delete(req.query.token);
     }
     return token;
   })
-  .then(tokenDeleted => validate.tokenExistsForHttp(tokenDeleted))
+  .then((tokenDeleted) => {
+    validate.tokenExistsForHttp(tokenDeleted);
+  })
   .then(() => {
     res.json({});
   })
@@ -87,15 +89,7 @@ const revoke = (req, res) => validate.tokenForHttp(req.query.token)
     res.json({ error: err.message });
   });
 
-const test = (req, res) => {
-  models.client.findAll().then((clients) => {
-    console.log(clients);
-    res.json(req.query);
-  });
-};
-
 export default {
   info,
   revoke,
-  test,
 };

--- a/api/src/controllers/Token.js
+++ b/api/src/controllers/Token.js
@@ -74,11 +74,12 @@ const revoke = (req, res) => validate.tokenForHttp(req.query.token)
   .then(() => db.accessTokens.delete(req.query.token))
   .then((token) => {
     if (token == null) {
-      db.refreshToken.delete(req.query.token).then(refreshToken => refreshToken);
+      return db.refreshToken.delete(req.query.token);
     }
     return token;
   })
   .then((tokenDeleted) => {
+    console.log('deleted', tokenDeleted);
     validate.tokenExistsForHttp(tokenDeleted);
   })
   .then(() => {

--- a/api/src/setup/loadModules.js
+++ b/api/src/setup/loadModules.js
@@ -75,8 +75,9 @@ export default function (server) {
 
   // From time to time we need to clean up any expired tokens
   // in the database
-  setInterval(() => {
-    accessTokens.removeExpired()
-      .catch(err => console.error('Error trying to remove expired tokens:', err.stack));
-  }, db.timeToCheckExpiredTokens * 1000);
+  // *** commenting this since tokens will not expire
+  // setInterval(() => {
+  //   accessTokens.removeExpired()
+  //     .catch(err => console.error('Error trying to remove expired tokens:', err.stack));
+  // }, db.timeToCheckExpiredTokens * 1000);
 }

--- a/api/src/setup/restAPI.js
+++ b/api/src/setup/restAPI.js
@@ -37,7 +37,6 @@ export default function (server) {
   server.get('/api/clientinfo', Client.info);
   server.get('/api/tokeninfo', Token.info);
   server.get('/api/revoke', Token.revoke);
-  server.get('/test', Token.test);
 
 
   // Options for the swagger docs

--- a/api/src/utils/crypto/index.js
+++ b/api/src/utils/crypto/index.js
@@ -32,8 +32,8 @@ export const uid = {
  * @param  {String} sub - The subject or identity of the token.
  * @return {String} The JWT Token
  */
-export const createToken = ({ exp = 3600, sub = '' } = {}) => {
-  const id = uid.generate(25);
+export const createToken = ({ exp = 3600, sub = '', length = 25 } = {}) => {
+  const id = uid.generate(length);
   const token = jwt.sign({
     jti: id,
     sub,

--- a/api/src/utils/db/index.js
+++ b/api/src/utils/db/index.js
@@ -160,14 +160,13 @@ export const authorizationCode = {
     const tk = jwt.decode(code);
     const id = tk.jti;
 
-
-    return Promise.resolve(models.authorization_code.create({
+    return models.authorization_code.create({
       code_secret: id,
       client_id,
       redirect_uri,
       user_id,
       scope,
-    }));
+    });
   },
 
   /**
@@ -227,7 +226,7 @@ export const refreshToken = {
 
   save: (token, user_id, client_id, scope) => {
     const id = jwt.decode(token).jti;
-    models.refresh_token.create({
+    return models.refresh_token.create({
       token_secret: id,
       user_id,
       client_id,

--- a/api/src/utils/db/index.js
+++ b/api/src/utils/db/index.js
@@ -101,10 +101,11 @@ export const accessTokens = {
         where: {
           token_secret: id,
         },
-      }).then((obj) => {
-        obj.destroy()
-          .then(() => obj);
-      }));
+      }).then(obj => models.access_token.destroy({
+        where: {
+          token_secret: id,
+        },
+      }).then(() => obj)));
     } catch (error) {
       return Promise.resolve(null);
     }
@@ -115,7 +116,7 @@ export const accessTokens = {
   */
   removeExpired: () => {
     const now = Date.now();
-    return models.access_token.findAll({
+    return models.access_token.destroy({
       where: {
         exp_date: {
           [models.Sequelize.Op.lt]: now,
@@ -181,14 +182,11 @@ export const authorizationCode = {
         where: {
           code_secret: id,
         },
-      }).then(obj =>
-        // obj.destroy()
-        models.authorization_code.destroy({
-          where: {
-            code_secret: id,
-          },
-        })
-          .then(a => obj)));
+      }).then(obj => models.authorization_code.destroy({
+        where: {
+          code_secret: id,
+        },
+      }).then(() => obj)));
     } catch (error) {
       return Promise.resolve(null);
     }
@@ -251,7 +249,11 @@ export const refreshToken = {
           token_secret: id,
         },
       }).then((obj) => {
-        obj.destroy()
+        models.refresh_token.destroy({
+          where: {
+            token_secret: id,
+          },
+        })
           .then(() => obj);
       }));
     } catch (error) {

--- a/api/src/utils/db/index.js
+++ b/api/src/utils/db/index.js
@@ -247,14 +247,12 @@ export const refreshToken = {
         where: {
           token_secret: id,
         },
-      }).then((obj) => {
-        models.refresh_token.destroy({
-          where: {
-            token_secret: id,
-          },
-        })
-          .then(() => obj);
-      }));
+      }).then(obj => models.refresh_token.destroy({
+        where: {
+          token_secret: id,
+        },
+      })
+        .then(() => obj)));
     } catch (error) {
       return Promise.resolve(null);
     }

--- a/api/src/utils/validate/index.js
+++ b/api/src/utils/validate/index.js
@@ -162,7 +162,7 @@ validate.isRefreshToken = ({ scope }) => scope != null && scope.indexOf('offline
  */
 validate.generateRefreshToken = ({ user_id, client_id, scope }) => {
   const refreshToken = crypto.createToken({ sub: user_id, exp: tokens.refreshToken.expiresIn });
-  return db.refreshTokens.save(refreshToken, user_id, client_id, scope)
+  return db.refreshToken.save(refreshToken, user_id, client_id, scope)
     .then(() => refreshToken);
 };
 
@@ -175,7 +175,7 @@ validate.generateRefreshToken = ({ user_id, client_id, scope }) => {
  */
 validate.generateToken = ({ user_id, client_id, scope }) => {
   const token = crypto.createToken({ sub: user_id, exp: tokens.accesstoken.expiresIn });
-  const expiration = tokens.accesstoken.calculateExpirationDate();
+  const expiration = tokens.calculateExpirationDate(tokens.accesstoken.expiresIn);
 
   return db.accessTokens.save(token, expiration, user_id, client_id, scope)
     .then(() => token);
@@ -189,10 +189,11 @@ validate.generateToken = ({ user_id, client_id, scope }) => {
  * @returns {Promise} The resolved refresh and access tokens as an array
  */
 validate.generateTokens = (authCode) => {
-  if (validate.isRefreshToken(authCode)) {
+  if (!validate.isRefreshToken(authCode)) {
+    console.log('Generating access token and refresh token...');
     return Promise.all([
       validate.generateToken(authCode),
-      // validate.generateRefreshToken(authCode),
+      validate.generateRefreshToken(authCode),
     ]);
   }
   return Promise.all([validate.generateToken(authCode)]);

--- a/api/src/utils/validate/index.js
+++ b/api/src/utils/validate/index.js
@@ -192,7 +192,7 @@ validate.generateTokens = (authCode) => {
   if (validate.isRefreshToken(authCode)) {
     return Promise.all([
       validate.generateToken(authCode),
-      validate.generateRefreshToken(authCode),
+      // validate.generateRefreshToken(authCode),
     ]);
   }
   return Promise.all([validate.generateToken(authCode)]);


### PR DESCRIPTION
Tried to just comment out the key refresh token parts, just for in case we need to reimplement them.
I tested the authorization grant, checked the database to see that no refresh token is being generated.
Besides that, the methodology used to make refresh tokens expireless was to set its duration for 100 years. I did this also for the access tokens.

Related isssue #37 